### PR TITLE
Update initial login instructions

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -48,8 +48,8 @@ pagewidth: 12
         <p>Install the platform using helm</p>
         <pre>helm upgrade --install epinio epinio/epinio -n epinio --create-namespace --set global.domain=&LT;INGRESS_IP&GT;.sslip.io</pre>
 
-        <p>Pull settings from the cluster</p>
-        <pre>epinio settings update</pre>
+        <p>Login to the cluster</p>
+        <pre>epinio login -u admin https://epinio.&LT;INGRESS_IP&GT;.sslip.io</pre>
 
         <p>Learn more in the <a href="https://docs.epinio.io/installation/">installation instructions</a>.</p>
       </div>


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1525
---

Added `epinio login` to home page instructions.
The `epinio settings update` command was removed, and you now have to login to get/update the settings file.