### PR TITLE
Remove useless trailing slash

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -51,7 +51,7 @@ pagewidth: 12
         <p>Login to the cluster</p>
         <pre>epinio login -u admin https://epinio.&LT;INGRESS_IP&GT;.sslip.io</pre>
 
-        <p>Learn more in the <a href="https://docs.epinio.io/installation/install_epinio/">installation instructions</a>.</p>
+        <p>Learn more in the <a href="https://docs.epinio.io/installation/install_epinio">installation instructions</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The trailing slash causes unexpected behavior, 404 and then we got the right page. Let's remove it.